### PR TITLE
Fix #5: JWT expiry check has off-by-one error - tokens valid 1 second too long

### DIFF
--- a/src/api/middleware/auth.js
+++ b/src/api/middleware/auth.js
@@ -27,7 +27,7 @@ const JWT_EXPIRY = process.env.JWT_EXPIRY || '24h';
                                                                                // BUG: Off-by-one error in expiry check
                                                                                      // Uses < instead of <= which means tokens are valid for 1 second longer than intended
                                                                                            const now = Math.floor(Date.now() / 1000);
-                                                                                                 if (decoded.exp < now) {
+                                                                                                 if (decoded.exp <= now) {
                                                                                                          return res.status(401).json({
                                                                                                                    error: 'Unauthorized',
                                                                                                                              message: 'Token has expired',


### PR DESCRIPTION
## Summary

Fix off-by-one error in JWT expiry check by changing `<` to `<=` so tokens expire exactly at the intended time.

## Approach

In src/api/middleware/auth.js around line 30, change the comparison operator in the token expiry check from `<` to `<=`. This ensures that a token whose `exp` timestamp exactly equals the current time (`now`) is treated as expired, rather than being valid for one additional second.

## Files Changed

- `src/api/middleware/auth.js`

## Related Issue

Fixes #5

## Testing

No tests were added with this change. Happy to add them if needed.
